### PR TITLE
Configurable instant search

### DIFF
--- a/lib/input-view.coffee
+++ b/lib/input-view.coffee
@@ -27,7 +27,7 @@ class InputView extends View
 
   handleEvents: ->
     # Setup event handlers
-    @subscriptions.add @findEditor.getModel().onDidChange => @updateSearchText()
+    @subscriptions.add atom.config.observe 'incremental-search.instantSearch', @handleInstantSearchConfigChange.bind(this)
 
     @subscriptions.add atom.commands.add @findEditor.element,
       'core:confirm': => @stopSearch()
@@ -43,11 +43,14 @@ class InputView extends View
     @regexOptionButton.on 'click', @toggleRegexOption
     @caseOptionButton.on 'click', @toggleCaseOption
 
-
-
     @searchModel.on 'updatedOptions', =>
       @updateOptionButtons()
       @updateOptionsLabel()
+
+  handleInstantSearchConfigChange: (instantSearch) ->
+    changeEventListener = if instantSearch then 'onDidChange' else 'onDidStopChanging'
+    @changeSubscription?.dispose()
+    @changeSubscription = @findEditor.getModel()[changeEventListener] => @updateSearchText()
 
   attached: ->
     return if @tooltipSubscriptions?
@@ -91,6 +94,7 @@ class InputView extends View
   destroy: ->
     @subscriptions?.dispose()
     @tooltipSubscriptions?.dispose()
+    @changeSubscription?.dispose()
 
   detach: ->
     @hideAllTooltips()

--- a/lib/isearch.coffee
+++ b/lib/isearch.coffee
@@ -8,6 +8,9 @@ module.exports =
     keepOptionsAfterSearch:
       type: 'boolean'
       default: true
+    instantSearch:
+      type: 'boolean'
+      default: false
 
   inputView: null
 

--- a/lib/isearch.coffee
+++ b/lib/isearch.coffee
@@ -4,14 +4,6 @@
 InputView = require './input-view'
 
 module.exports =
-  config:
-    keepOptionsAfterSearch:
-      type: 'boolean'
-      default: true
-    instantSearch:
-      type: 'boolean'
-      default: false
-
   inputView: null
 
   activate: (state) ->

--- a/package.json
+++ b/package.json
@@ -19,5 +19,17 @@
     "emissary": "1.x",
     "underscore-plus": "1.x",
     "atom-space-pen-views": "^2.0.3"
+  },
+  "configSchema": {
+    "instantSearch": {
+      "type": "boolean",
+      "default": false,
+      "description": "Search as you type, instead of waiting until you stop typing."
+    },
+    "keepOptionsAfterSearch": {
+      "type": "boolean",
+      "default": true,
+      "description": "Keep the values of the Match Case and Use Regex options between searches."
+    }
   }
 }


### PR DESCRIPTION
This more-or-less clones atom/find-and-replace#721 into gangstead/atom-incremental-search#55. Thanks for the clean roadmap. 

9edd9a9 can be dropped, if it's not desired.